### PR TITLE
Parameterize Let's Encrypt configuration and update domain

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -82,4 +82,4 @@ puma_socket: "{{sockets_path}}/puma.sock"
 
 letsencrypt_email: alex.musayev@gmail.com
 letsencrypt_dir: /var/www/letsencrypt
-letsencrypt_domain_name: frf.im
+letsencrypt_domain_name: status.fffeeder.com

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -20,7 +20,7 @@
     state: restarted
 
 - name: "create letsencrypt certificate"
-  shell: "certbot certonly --non-interactive --webroot --webroot-path /var/www/letsencrypt --email alex.musayev@gmail.com --agree-tos --domain frf.im"
+  shell: "certbot certonly --non-interactive --webroot --webroot-path {{letsencrypt_dir}} --email {{letsencrypt_email}} --agree-tos --domain {{letsencrypt_domain_name}}"
   args:
     creates: "/etc/letsencrypt/live/{{letsencrypt_domain_name}}"
 
@@ -33,4 +33,4 @@
   cron:
     name: "letsencrypt_renewal"
     special_time: "weekly"
-    job: "certbot certonly --non-interactive --webroot --webroot-path /var/www/letsencrypt --email alex.musayev@gmail.com --agree-tos --domain frf.im && service nginx reload"
+    job: "certbot certonly --non-interactive --webroot --webroot-path {{letsencrypt_dir}} --email {{letsencrypt_email}} --agree-tos --domain {{letsencrypt_domain_name}} && service nginx reload"


### PR DESCRIPTION
## Summary
Refactored the Let's Encrypt role to use configurable variables instead of hardcoded values, and updated the domain configuration.

## Key Changes
- Replaced hardcoded paths, email, and domain values with Ansible variables in the certbot commands
  - `/var/www/letsencrypt` → `{{letsencrypt_dir}}`
  - `alex.musayev@gmail.com` → `{{letsencrypt_email}}`
  - `frf.im` → `{{letsencrypt_domain_name}}`
- Updated both the certificate creation task and the weekly renewal cron job to use the new variables
- Changed the default domain from `frf.im` to `status.fffeeder.com` in group variables

## Implementation Details
- All Let's Encrypt configuration is now centralized in `group_vars/all.yml`, making it easier to manage across different environments
- The variables are consistently applied across both the initial certificate creation and the automated renewal process
- This change maintains backward compatibility while improving flexibility and maintainability
